### PR TITLE
Use UniformWrapper<T> for Camera uniforms

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -50,10 +50,7 @@ Make a post processing "stack" which can ping pong between two intermediate text
 
 ## Presently
 
-Render to Texture
-
-- made pub Vec3 Vec4 types, should try using them
-- can my Uniform structs use Vec3, Vec4 instead of the array syntax? Might make life easier
+- investigate migration to `tao` from winit.
 
 THEN we can use "camera" with depth textures to render shadows
 
@@ -65,3 +62,7 @@ THEN we can use "camera" with depth textures to render shadows
 Do I want a GUI?
 	- https://github.com/emilk/egui#example
 Things and stuff and people and places....
+
+## Remember
+
+uniforms require 16-byte (4 float field spacing)

--- a/res/shaders/model.wgsl
+++ b/res/shaders/model.wgsl
@@ -100,7 +100,7 @@ fn inverse_lerp(a: f32, b: f32, v: f32) -> f32 {
     return (v - a) / (b - a);
 }
 
-// Returns the light dir depending on light type
+// Returns the light dir depending on light type. Note, this is direction TO the light.
 fn fs_get_light_dir(in: VertexOutput) -> vec3<f32> {
     if (light.light_type == 1 || light.light_type == 2) {
         // point or spot

--- a/src/lib/compositor.rs
+++ b/src/lib/compositor.rs
@@ -247,7 +247,7 @@ impl AppState for Compositor {
 
     fn update(&mut self, gpu_state: &mut super::gpu_state::GpuState, dt: instant::Duration) {
         self.time += dt;
-        self.uniform.write(&mut gpu_state.queue);
+        self.uniform.write(&gpu_state.queue);
     }
 
     fn render(

--- a/src/lib/util.rs
+++ b/src/lib/util.rs
@@ -56,19 +56,7 @@ where
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-            label: Some("Uniform Bind Group Layout"),
-        });
+        let bind_group_layout = Self::bind_group_layout(device);
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             layout: &bind_group_layout,
@@ -88,12 +76,32 @@ where
         }
     }
 
+    pub fn bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("Uniform Bind Group Layout"),
+        })
+    }
+
+    pub fn read(&self) -> &D {
+        &self.data
+    }
+
     pub fn edit(&mut self) -> &mut D {
         self.dirty = true;
         &mut self.data
     }
 
-    pub fn write(&mut self, queue: &mut wgpu::Queue) {
+    pub fn write(&mut self, queue: &wgpu::Queue) {
         if self.dirty {
             queue.write_buffer(&self.buffer, 0, bytemuck::cast_slice(&[self.data]));
             self.dirty = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,7 @@ where
 {
     let instances: Vec<_> = positions
         .iter()
-        .map(|p| {
-            model::Instance::new(
-                (*p).into(),
-                Quat::from_axis_angle(Vec3::unit_z(), deg(0.0)),
-            )
-        })
+        .map(|p| model::Instance::new((*p).into(), Quat::from_axis_angle(Vec3::unit_z(), deg(0.0))))
         .collect();
 
     resources::load_model_sync(
@@ -82,10 +77,10 @@ fn main() {
             let directional_light = light::Light::new_directional(
                 &gpu_state.device,
                 &light::DirectionalLightDescriptor {
-                    direction: (1.0, 1.0, 1.0).into(),
+                    direction: (1.0, 1.0, 0.0).into(),
                     ambient: (0.0, 0.0, 0.0).into(),
                     color: (0.0, 0.0, 1.0).into(),
-                    constant_attenuation: 2.0,
+                    constant_attenuation: 1.0,
                 },
             );
 


### PR DESCRIPTION
Use `UniformWrapper<T>` when possible, and use explicit `Vec`, `Mat`, etc types in uniform data payloads. Massive cleanup of `Light` by using the payload to store values instead of it being written right before writing to queue.